### PR TITLE
Removed windows incompatible path.resolve call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const getSFTPConnection = require('./utils/getSFTPConnection');
 
 module.exports = {
@@ -24,7 +23,7 @@ module.exports = {
         }
 
         try {
-          await sftp.put(file.buffer, path.resolve(basePath, fileName))
+          await sftp.put(file.buffer, `${basePath}/${fileName}`)
         } catch (e) {
           console.error(e);
         }


### PR DESCRIPTION
When uploading the plugin uses the "path resolve" method which is problematic when Strapi is running in an Windows environment (fairly common in development). Path resolve will produce a windows path with backslashes prepended drive letter, causing the upload to fail.

This has been fixed by using a simple string concatenation which should not cause Problems and the _delete_ method already uses the same approach already anyway.

After removing the resolve() importing 'path' is also no longer necessary.